### PR TITLE
Add missing close for renew event

### DIFF
--- a/lib/interim_wifi/wifi_manager.ex
+++ b/lib/interim_wifi/wifi_manager.ex
@@ -222,6 +222,7 @@ defmodule Nerves.InterimWiFi.WiFiManager do
 
   ## Context: :up
   defp consume(:up, :renew, state), do: state
+  defp consume(:up, {:renew, _info}, state), do: state
   defp consume(:up, :ifup, state), do: state
   defp consume(:up, :ifdown, state) do
     state


### PR DESCRIPTION
I still have issues with the :renew event even with the last commit on master. 
This commit fix the following error message:

> 00:05:10.587 [error] GenServer :"Nerves.InterimWifi.Interface.wlan0" terminating
> ** (FunctionClauseError) no function clause matching in Nerves.InterimWiFi.WiFiManager.consume/3
>     (nerves_interim_wifi) lib/interim_wifi/wifi_manager.ex:124: Nerves.InterimWiFi.WiFiManager.consume(:)
>     (nerves_interim_wifi) lib/interim_wifi/wifi_manager.ex:114: Nerves.InterimWiFi.WiFiManager.handle_in2
>     (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
>     (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
>     (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
> Last message: {:renew, %{domain: "", ifname: "wlan0", ipv4_address: "192.168.88.200", ipv4_broadcast: ""}
> State: %Nerves.InterimWiFi.WiFiManager{context: :up, dhcp_pid: #PID<0.406.0>, ifname: "wlan0", settings:}
> 
> =CRASH REPORT==== 1-Jan-1970::00:05:10 ===
>   crasher:
>     initial call: Elixir.Nerves.InterimWiFi.WiFiManager:init/1
>     pid: <0.363.0>
>     registered_name: 'Nerves.InterimWifi.Interface.wlan0'
>     exception exit: {function_clause,
>                         [{'Elixir.Nerves.InterimWiFi.WiFiManager',consume,
>                              [up,
>                               {renew,
>                                   #{domain => <<>>,
>                                     ifname => <<"wlan0">>,
>                                     ipv4_address => <<"192.168.88.200">>,
>                                     ipv4_broadcast => <<>>,
>                                     ipv4_gateway => <<"192.168.88.1">>,
>                                     ipv4_subnet_mask => <<"255.255.255.0">>,
>                                     nameservers => [<<"192.168.88.1">>]}},
>                               #{'__struct__' => 'Elixir.Nerves.InterimWiFi.WiFiManager',
>                                 context => up,
>                                 dhcp_pid => <0.406.0>,
>                                 ifname => <<"wlan0">>,
>                                 settings => [{ssid,<<"test">>},
>                                  {key_mgmt,'WPA-PSK'},
>                                  {psk,<<"test">>}],
>                                 wpa_pid => <0.381.0>}],
>                              [{file,"lib/interim_wifi/wifi_manager.ex"},
>                               {line,124}]},
>                          {'Elixir.Nerves.InterimWiFi.WiFiManager',
>                              handle_info,2,
>                              [{file,"lib/interim_wifi/wifi_manager.ex"},
>                               {line,114}]},
>                          {gen_server,try_dispatch,4,
>                              [{file,"gen_server.erl"},{line,601}]},
>                          {gen_server,handle_msg,5,
>                              [{file,"gen_server.erl"},{line,667}]},
>                          {proc_lib,init_p_do_apply,3,
>                              [{file,"proc_lib.erl"},{line,247}]}]}
>       in function  gen_server:terminate/7 (gen_server.erl, line 812)
>     ancestors: ['Elixir.Nerves.InterimWiFi.IFSupervisor',
>                   'Elixir.Nerves.InterimWiFi.Supervisor',<0.105.0>]
>     messages: []
>     links: [<0.381.0>,<0.406.0>,<0.109.0>]
>     dictionary: []
>     trap_exit: false
>     status: running
>     heap_size: 987
>     stack_size: 27
>     reductions: 4266
>   neighbours:
>     neighbour: [{pid,<0.406.0>},
>                   {registered_name,[]},
>                   {initial_call,
>                       {'Elixir.Nerves.InterimWiFi.Udhcpc',init,
>                           ['Argument__1']}},
>                   {current_function,{gen_server,loop,6}},
>                   {ancestors,
>                       ['Nerves.InterimWifi.Interface.wlan0',
>                        'Elixir.Nerves.InterimWiFi.IFSupervisor',
>                        'Elixir.Nerves.InterimWiFi.Supervisor',<0.105.0>]},
>                   {messages,[]},
>                   {links,[<0.363.0>,#Port<0.5331>]},
>                   {dictionary,[]},
>                   {trap_exit,false},
>                   {status,waiting},
>                   {heap_size,987},
>                   {stack_size,9},
>                   {reductions,891}]
>     neighbour: [{pid,<0.381.0>},
>                   {registered_name,[]},
>                   {initial_call,
>                       {'Elixir.Nerves.WpaSupplicant',init,['Argument__1']}},
>                   {current_function,{gen_server,loop,6}},
>                   {ancestors,
>                       ['Nerves.InterimWifi.Interface.wlan0',
>                        'Elixir.Nerves.InterimWiFi.IFSupervisor',
>                        'Elixir.Nerves.InterimWiFi.Supervisor',<0.105.0>]},
>                   {messages,[]},
>                   {links,[<0.363.0>,#Port<0.4525>]},
>                   {dictionary,[]},
>                   {trap_exit,false},
>                   {status,waiting},
>                   {heap_size,1598},
>                   {stack_size,9},
>                   {reductions,1683}]

Have a nice day :)