### PR TITLE
Handle context for :up, :bound

### DIFF
--- a/lib/interim_wifi/wifi_manager.ex
+++ b/lib/interim_wifi/wifi_manager.ex
@@ -237,6 +237,7 @@ defmodule Nerves.InterimWiFi.WiFiManager do
   ## Context: :up
   defp consume(:up, :renew, state), do: state
   defp consume(:up, :ifup, state), do: state
+  defp consume(:up, {:bound, _info}, state), do: state # already configured.
   defp consume(:up, :ifdown, state) do
     state
       |> stop_udhcpc


### PR DESCRIPTION
I'm not exactly sure what causes this in my environment, but i recently started hitting this:
``` elixir
** (FunctionClauseError) no function clause matching in Nerves.InterimWiFi.WiFiManager.consume/3
  (nerves_interim_wifi) lib/interim_wifi/wifi_manager.ex:149: consume(:up, {:bound, 
  %{ domain: "T-mobile.com", 
       ifname: "wlan0", 
       ipv4_address: "192.168.29.136", 
       ipv4_broadcast: "192.168.29.255", 
       ipv4_gateway: "192.168.29.1", 
       ipv4_subnet_mask: "255.255.255.0", 
      nameservers: ["192.168.29.1"]
  }
}, %Nerves.InterimWiFi.WiFiManager{
     context: :up, 
     dhcp_pid: #PID<0.496.0>, 
     ifname: "wlan0", 
     settings: [ssid: "supersecretssid", key_mgmt: :"WPA-PSK", psk: "super_secret_password"], 
     wpa_pid: #PID<0.414.0>
})
```


Not entirely sure if this is the correct fix. 