### PR TITLE
Remove starting application installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,7 @@ Connect to WiFi networks on Nerves platforms.
     end
     ```
 
-2. Ensure nerves_interim_wifi is started before your application:
-  ``` elixir
-  def application do
-    [applications: [:nerves_interim_wifi]]
-  end
-  ```
-
-3. Set the regulatory domain in your `config.exs`. This should be set to the
+2. Set the regulatory domain in your `config.exs`. This should be set to the
    ISO 3166-1 alpha-2 country code where the device is running. If your device
    ships to more than one country, see `Nerves.InterimWiFi.set_regulatory_domain\1`.
      * if unset, the default regulatory domain is the world domain, "00"


### PR DESCRIPTION
In Elixir >= 1.4 we no longer need to add the application because it is
configured in the dependency.

Even knowing of the change to Elixir 1.4 I got caught up on this because
I was focused on getting wifi setup. Since I added applications to my
application config I ran into other modules not working on my device. In
my host config I didn't have that issue so the problem was further
exacerbated by the modules being available on the host iex session.

Amos King @adkron amos@binarynoggin.com