### PR TITLE
Update elixir_make dep and set runtime: false

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Nerves.InterimWiFi.Mixfile do
 
   defp deps do
     [
-      {:elixir_make, "~> 0.3"},
+      {:elixir_make, "~> 0.4", runtime: false },
       {:ex_doc, "~> 0.11", only: :dev},
       {:nerves_network_interface, "~> 0.4.0"},
       {:nerves_wpa_supplicant, "~> 0.3.0"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "nerves_network_interface": {:hex, :nerves_network_interface, "0.4.0", "a8e7662cd56fb4fe9060c891d35c43bbbff692ee6fd2d5efd538717da0cd96b8", [:make, :mix], [{:elixir_make, "~> 0.3", [hex: :elixir_make, optional: false]}]},
-  "nerves_wpa_supplicant": {:hex, :nerves_wpa_supplicant, "0.3.0", "dfda748df2662e1e9e95df6662c3a512d371ef23359b2c090b9c8c884b236a3d", [:make, :mix], [{:elixir_make, "~> 0.3", [hex: :elixir_make, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "nerves_network_interface": {:hex, :nerves_network_interface, "0.4.0", "a8e7662cd56fb4fe9060c891d35c43bbbff692ee6fd2d5efd538717da0cd96b8", [:make, :mix], [{:elixir_make, "~> 0.3", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "nerves_wpa_supplicant": {:hex, :nerves_wpa_supplicant, "0.3.0", "dfda748df2662e1e9e95df6662c3a512d371ef23359b2c090b9c8c884b236a3d", [:make, :mix], [{:elixir_make, "~> 0.3", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"}}


### PR DESCRIPTION
Assuming all other applications that use elixir_make do this, it should
no longer appear in the release or be started at boot.